### PR TITLE
Lexer fixes

### DIFF
--- a/bundles/basic_modes/lexers/python.lua
+++ b/bundles/basic_modes/lexers/python.lua
@@ -103,10 +103,6 @@ local identifier = token(l.IDENTIFIER, l.word)
 -- Operators.
 local operator = token(l.OPERATOR, S('!%^&*()[]{}-=+/|:;.,?<>~`'))
 
--- Decorators.
-local decorator = token('decorator',
-                        #P('@') * l.starts_line('@' * l.nonnewline^0))
-
 M._rules = {
   {'whitespace', ws},
   {'keyword', keyword},
@@ -116,7 +112,6 @@ M._rules = {
   {'comment', comment},
   {'string', string},
   {'number', number},
-  {'decorator', decorator},
   {'operator', operator},
   {'any_char', l.any_char},
 }

--- a/bundles/c/c_lexer.moon
+++ b/bundles/c/c_lexer.moon
@@ -9,21 +9,21 @@ howl.aux.lpeg_lexer ->
   identifer = c 'identifer', ident
 
   keyword = c 'keyword', word {
+    -- C++ keywords: todo, break out into separate mode later
+    'alignas', 'alignof', 'and_eq', 'and', 'asm', 'bitand', 'bitor', 'bool',
+    'catch', 'char16_t', 'char32_t', 'char', 'class', 'compl', 'constexpr',
+    'const_cast', 'decltype', 'delete', 'dynamic_cast', 'explicit', 'export',
+    'false', 'friend', 'mutable', 'namespace', 'new', 'noexcept', 'not_eq',
+    'not', 'nullptr', 'operator', 'or_eq', 'or', 'private', 'protected',
+    'public', 'reinterpret_cast', 'static_assert', 'static_cast', 'template',
+    'this', 'thread_local', 'throw', 'true', 'try', 'typeid', 'typename',
+    'union', 'using', 'virtual', 'wchar_t', 'while', 'xor_eq', 'xor'
+
     'auto', '_Bool', 'break', 'case', 'char', '_Complex', 'const', 'continue',
     'default', 'double', 'do', 'else', 'enum', 'extern', 'float', 'for', 'goto',
     'if', '_Imaginary', 'inline', 'int', 'long', 'register', 'restrict',
     'return', 'short', 'signed', 'sizeof', 'static', 'struct', 'switch',
     'typedef', 'union', 'unsigned', 'void', 'volatile', 'while'
-
-    -- C++ keywords: todo, break out into separate mode later
-    'alignas', 'alignof', 'and', 'and_eq', 'asm', 'bitand', 'bitor', 'bool',
-    'catch', 'char', 'char16_t', 'char32_t', 'class', 'compl', 'constexpr',
-    'const_cast', 'decltype', 'delete', 'dynamic_cast', 'explicit', 'export',
-    'false', 'friend', 'mutable', 'namespace', 'new', 'noexcept', 'not',
-    'not_eq', 'nullptr', 'operator', 'or', 'or_eq', 'private', 'protected',
-    'public', 'reinterpret_cast', 'static_assert', 'static_cast', 'template',
-    'this', 'thread_local', 'throw', 'true', 'try', 'typeid', 'typename',
-    'union', 'using', 'virtual', 'wchar_t', 'while', 'xor', 'xor_eq',
   }
 
   operator = c 'operator', S('+-*/%=<>~&^|!(){}[];.')^1


### PR DESCRIPTION
- Reorder stuff in the C/C++ lexer to correctly lex things like `static_assert`.
- Remove Python decorator support. It disabled lexing for the rest of the line, which was ugly, and it was kind of broken.