### PR TITLE
Python decorator styling

### DIFF
--- a/bundles/basic_modes/lexers/python.lua
+++ b/bundles/basic_modes/lexers/python.lua
@@ -103,6 +103,9 @@ local identifier = token(l.IDENTIFIER, l.word)
 -- Operators.
 local operator = token(l.OPERATOR, S('!%^&*()[]{}-=+/|:;.,?<>~`'))
 
+local decorator = token('decorator',
+                        #P('@') * l.starts_line('@' * l.word^0))
+
 M._rules = {
   {'whitespace', ws},
   {'keyword', keyword},
@@ -112,6 +115,7 @@ M._rules = {
   {'comment', comment},
   {'string', string},
   {'number', number},
+  {'decorator', decorator},
   {'operator', operator},
   {'any_char', l.any_char},
 }

--- a/bundles/basic_modes/lexers/python.lua
+++ b/bundles/basic_modes/lexers/python.lua
@@ -103,8 +103,8 @@ local identifier = token(l.IDENTIFIER, l.word)
 -- Operators.
 local operator = token(l.OPERATOR, S('!%^&*()[]{}-=+/|:;.,?<>~`'))
 
-local decorator = token('decorator',
-                        #P('@') * l.starts_line('@' * l.word^0))
+local dotted_name = l.word * ('.' * l.word)^0
+local decorator = token('decorator', S'@' * dotted_name^-1)
 
 M._rules = {
   {'whitespace', ws},

--- a/bundles/basic_modes/style_aliases.moon
+++ b/bundles/basic_modes/style_aliases.moon
@@ -6,6 +6,7 @@ with style
   .define_default 'attribute', 'key'
   .define_default 'at_rule', 'preproc'
   .define_default 'cdata', 'comment'
+  .define_default 'decorator', 'preproc'
   .define_default 'doctype', 'comment'
   .define_default 'element', 'type'
   .define_default 'em', 'emphasis'


### PR DESCRIPTION
@kirbyfan64 - Do you mind trying this out? This fixes the issue with the entire decorator line being unstyled. Instead, the '@' and just the following word is styled using the 'preproc' style.