### PR TITLE
Various file preview fixes

### DIFF
--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -340,7 +340,6 @@ class Buffer extends PropertyObject
   remove_sci_ref: (sci) =>
     @_scis = [s for s in *@_scis when s != sci and s != nil]
     @_sci = @_scis[1] if sci == @_sci
-    @_last_shown = os.time! if #@_scis == 0
 
   @property scis: get: =>
     [sci for _, sci in pairs @_scis when sci != nil]

--- a/lib/howl/interactions/location_selection.moon
+++ b/lib/howl/interactions/location_selection.moon
@@ -13,15 +13,22 @@ get_preview_buffer = (file, preview_buffers) ->
   return buffer if buffer
 
   buffer = Buffer mode.for_file file
-  contents = file\read 8192
-  size = ' (~'..tostring(math.ceil(file.size / 1024))..'KB)'
+  title = file.basename
+  local contents
+  ok, result = pcall -> contents = file\read 8192
 
-  if contents.is_valid_utf8
-    buffer.title = 'Preview: '..file.basename..size
-    buffer.text = contents
+  if ok
+    size = file.size
+    title ..= ' (~'..tostring(math.floor(size / 1024))..'KB)'
+    if size == 0 or contents.is_valid_utf8
+      buffer.title = "Preview: #{title}"
+      buffer.text = contents or ''
+    else
+      buffer.title = "No Preview: #{title}"
+      buffer.text = 'Preview not available.'
   else
-    buffer.title = 'No Preview: '..file.basename..size
-    buffer.text = 'Cannot preview - not a UTF-8 text file.'
+    buffer.title = "No Preview: #{title}"
+    buffer.text = result
 
   buffer.read_only = true
   preview_buffers[file.path] = buffer

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -462,7 +462,7 @@ class Editor extends PropertyObject
       @_buf.properties.position = @cursor.pos
       @_buf.properties.line_at_top = @line_at_top
       @_buf\remove_sci_ref @sci
-      unless opts.preview or @_is_previewing
+      unless @_is_previewing
         @_buf.last_shown = os.time!
 
     @_is_previewing = opts.preview

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -120,12 +120,14 @@ class Editor extends PropertyObject
       on_destroy: gobject_signal.unref_handle @bin\on_destroy ->
         theme.unregister_background_widget @sci\to_gobject!
         @buffer\remove_sci_ref @sci
+        @buffer.last_shown = os.time! unless @_is_previewing
         signal.emit 'editor-destroyed', editor: self
     }
 
     theme.register_background_widget @sci\to_gobject!
 
     @buffer = buffer
+    @_is_previewing = false
 
     append _editors, self
 
@@ -135,39 +137,7 @@ class Editor extends PropertyObject
     get: => @_buf
     set: (buffer) =>
       signal.emit 'before-buffer-switch', editor: self, current_buffer: @_buf, new_buffer: buffer
-      @selection\remove!
-
-      if @_buf
-        @_buf.properties.position = @cursor.pos
-        @_buf.properties.line_at_top = @line_at_top
-        @_buf\remove_sci_ref @sci
-
-      prev_buffer = @_buf
-      @_buf = buffer
-      @indicator.title.label = buffer.title
-
-      if buffer.activity and buffer.activity.is_running!
-        with @indicator.activity
-          \start!
-          \show!
-      elseif rawget(@indicator, 'activity')
-        with @indicator.activity
-          \stop!
-          \hide!
-
-      @sci\set_doc_pointer(buffer.doc)
-
-      @_set_config_settings!
-      style.set_for_buffer @sci, buffer
-      highlight.set_for_buffer @sci, buffer
-      buffer\add_sci_ref @sci
-
-      if buffer.properties.line_at_top
-        @line_at_top = buffer.properties.line_at_top
-
-      pos = buffer.properties.position or 1
-      pos = math.max 1, math.min pos, #buffer
-      @cursor.pos = pos
+      @_show_buffer buffer
       signal.emit 'after-buffer-switch', editor: self, current_buffer: buffer, old_buffer: prev_buffer
 
   @property current_line: get: => @buffer.lines[@cursor.line]
@@ -313,6 +283,9 @@ class Editor extends PropertyObject
     @cursor.column = column + delta
     @line_at_top = top_line
     error ret unless status
+
+  preview: (buffer) =>
+    @_show_buffer buffer, preview: true
 
   indent: => if @buffer.mode.indent then @buffer.mode\indent self
 
@@ -482,6 +455,44 @@ class Editor extends PropertyObject
 
 
   -- private
+  _show_buffer: (buffer, opts={}) =>
+    @selection\remove!
+
+    if @_buf
+      @_buf.properties.position = @cursor.pos
+      @_buf.properties.line_at_top = @line_at_top
+      @_buf\remove_sci_ref @sci
+      unless opts.preview or @_is_previewing
+        @_buf.last_shown = os.time!
+
+    @_is_previewing = opts.preview
+    prev_buffer = @_buf
+    @_buf = buffer
+    @indicator.title.label = buffer.title
+
+    if buffer.activity and buffer.activity.is_running!
+      with @indicator.activity
+        \start!
+        \show!
+    elseif rawget(@indicator, 'activity')
+      with @indicator.activity
+        \stop!
+        \hide!
+
+    @sci\set_doc_pointer(buffer.doc)
+
+    @_set_config_settings!
+    style.set_for_buffer @sci, buffer
+    highlight.set_for_buffer @sci, buffer
+    buffer\add_sci_ref @sci
+
+    if buffer.properties.line_at_top
+      @line_at_top = buffer.properties.line_at_top
+
+    pos = buffer.properties.position or 1
+    pos = math.max 1, math.min pos, #buffer
+    @cursor.pos = pos
+
   _set_config_settings: =>
     buf = @buffer
     config = buf.config

--- a/lib/howl/ustring.moon
+++ b/lib/howl/ustring.moon
@@ -218,6 +218,7 @@ properties =
   ureverse: => g_string C.g_utf8_strreverse(const_char_p(@), #@)
   is_empty: => #@ == 0
   is_blank: => @find('%S') == nil
+  is_valid_utf8: => C.g_utf8_validate(ffi.cast('const char *', @), #@, nil) != 0
   stripped: => @match '%s*(.-)%s*$'
 
 getmetatable('').__index = (k) =>

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -28,7 +28,7 @@ config.define
 
 config.define
   name: 'preview_files'
-  description: 'Whether to automatically preview files when switching between them'
+  description: 'Whether to automatically preview the selected file or buffer'
   default: true
   type_of: 'boolean'
   scope: 'global'

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -25,3 +25,10 @@ config.define
   description: 'Whether to automatically format code when possible'
   default: true
   type_of: 'boolean'
+
+config.define
+  name: 'preview_files'
+  description: 'Whether to automatically preview files when switching between them'
+  default: true
+  type_of: 'boolean'
+  scope: 'global'

--- a/spec/application_spec.moon
+++ b/spec/application_spec.moon
@@ -67,12 +67,11 @@ describe 'Application', ->
     hidden_buffer.title = 'hidden'
 
     last_shown_buffer = application\new_buffer!
-    last_shown_buffer\add_sci_ref sci
-    last_shown_buffer\remove_sci_ref sci
+    editor = Editor last_shown_buffer
     last_shown_buffer.title = 'last_shown'
 
     visible_buffer = application\new_buffer!
-    visible_buffer\add_sci_ref sci
+    editor.buffer = visible_buffer
     visible_buffer.title = 'visible'
 
     buffers = [b.title for b in *application.buffers]

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -159,15 +159,6 @@ describe 'Buffer', ->
     b\add_sci_ref sci
     assert.true b.showing
 
-  it '.last_shown returns a timestamp indicating when it was last shown', ->
-    b = buffer ''
-    assert.is_nil b.last_shown
-    ts = os.time!
-    b\add_sci_ref sci
-    assert.is_true b.last_shown >= ts
-    b\remove_sci_ref sci
-    assert.is_true b.last_shown <= os.time!
-
   describe '.multibyte', ->
     it 'returns true if the buffer contains multibyte characters', ->
       assert.is_false buffer('vanilla').multibyte

--- a/spec/interactions/buffer_selection_spec.moon
+++ b/spec/interactions/buffer_selection_spec.moon
@@ -15,7 +15,9 @@ describe 'buffer_selection', ->
   before_each ->
     app.window = Window!
     app.window\realize!
-    editor = {}
+    editor = {
+      preview: (@buffer) => nil
+    }
     command_line = app.window.command_line
 
     for b in *app.buffers

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -281,6 +281,25 @@ describe 'Editor', ->
       editor.buffer = buffer2
       assert.equal 15, cursor.pos
 
+    it 'updates .last_shown for buffer switched out', ->
+      time = os.time
+      now = time!
+      os.time = -> now
+      pcall ->
+        editor.buffer = Buffer {}
+      os.time = time
+      assert.same now, buffer.last_shown
+
+  context 'previewing', ->
+    it 'does not update last_shown for previewed or switched out buffer', ->
+      buffer.last_shown = 1
+      new_buffer = Buffer {}
+      new_buffer.last_shown = 2
+      editor\preview new_buffer
+      assert.same 1, buffer.last_shown
+      editor.buffer = Buffer {}
+      assert.same 2, new_buffer.last_shown
+
   context 'indentation, tabs, spaces and backspace', ->
 
     it 'defines a "tab_width" config variable, defaulting to 8', ->

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -291,14 +291,21 @@ describe 'Editor', ->
       assert.same now, buffer.last_shown
 
   context 'previewing', ->
-    it 'does not update last_shown for previewed or switched out buffer', ->
-      buffer.last_shown = 1
+    it 'does not update last_shown for previewed buffer', ->
       new_buffer = Buffer {}
       new_buffer.last_shown = 2
       editor\preview new_buffer
-      assert.same 1, buffer.last_shown
       editor.buffer = Buffer {}
       assert.same 2, new_buffer.last_shown
+
+    it 'updates .last_shown for original buffer switched out', ->
+      time = os.time
+      now = time!
+      os.time = -> now
+      pcall ->
+        editor\preview Buffer {}
+      os.time = time
+      assert.same now, buffer.last_shown
 
   context 'indentation, tabs, spaces and backspace', ->
 

--- a/spec/ustring_spec.moon
+++ b/spec/ustring_spec.moon
@@ -40,6 +40,12 @@ describe 'ustrings', ->
     assert.equal 0, 'a'\ucompare('a')
     assert.is_true 'ö'\ucompare('ä') > 0
 
+  it 'is_valid_utf8(s) return true for valid utf8 strings only', ->
+    assert.is_true ('abc\194\128').is_valid_utf8
+    assert.is_true ('\127').is_valid_utf8
+    assert.is_false ('\128').is_valid_utf8
+    assert.is_false ('abc\194').is_valid_utf8
+
   describe 'usub(i, [j])', ->
     s = 'aåäöx'
 


### PR DESCRIPTION
- Don't reset last_shown on buffers during preview
- Add config.preview_files
- Don't preview binary files

Also, now the *-buffer-switch events are not fired during previewing.