### PR TITLE
More Python and Ruby lexer fixes

### DIFF
--- a/bundles/basic_modes/mode_definitions.moon
+++ b/bundles/basic_modes/mode_definitions.moon
@@ -299,9 +299,9 @@ common_auto_pairs = {
     comment_syntax: '#'
     indentation: {
       more_after: {
-        { ':%s*$', 'else:%s*$' }
+        { ':%s*$' }
       }
-      less_for: { 'else:%s*$'}
+      less_for: { 'else%s*:%s*$' }
     }
     auto_pairs: common_auto_pairs
     structure: (editor) =>

--- a/bundles/ruby/ruby_mode.moon
+++ b/bundles/ruby/ruby_mode.moon
@@ -68,7 +68,7 @@ continuation_indent = (line, indent_level) ->
   code_blocks:
     multiline: {
       { r'\\s+do(?:\\s*\\|[^|]+\\|)?\\s*$', '^%s*end', 'end' },
-      { r'^\\s*def\\s+\\w[\\w.\\d]+(?:\\s*\\([^)]*\\))?\\s*$', '^%s*end', 'end' },
+      { r'^\\s*def\\s+\\w[\\w.\\d?!]+(?:\\s*\\([^)]*\\))?\\s*$', '^%s*end', 'end' },
       { r'^\\s*(class|module)\\s+\\p{Lu}[\\w\\d]*(\\s*<\\s*\\p{Lu}[\\w\\d]*)?\\s*$', '^%s*end', 'end' },
       { r'^\\s*(if|unless|case)\\s+', '^%s*end', 'end' },
       { '{%s*$', '^%s*}', '}'},

--- a/bundles/ruby/spec/ruby_mode_spec.moon
+++ b/bundles/ruby/spec/ruby_mode_spec.moon
@@ -28,7 +28,9 @@ describe 'Ruby mode', ->
 
     indents = {
       'pending function definitions': {
-        'def foo'
+        'def foo',
+        'def abc?',
+        'def def!',
       }
       'pending class declarations': {
         'class Frob',


### PR DESCRIPTION
1. The Python lexer currently won't indent after `else:`.
2. Ruby function names can have the `!` and `?` characters.
