### PR TITLE
Add build-exec

### DIFF
--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -329,13 +329,13 @@ get_project_root = ->
 command.register
   name: 'project-exec',
   description: 'Runs an external command from within the project directory'
-  input: -> interact.get_external_command path: get_project_root!.root
+  input: -> interact.get_external_command path: get_project_root!
   handler: launch_cmd
 
 command.register
   name: 'project-build'
   description: 'Runs the command in config.project_build_command from within the project directory'
-  handler: -> launch_cmd get_project_root!.root, config.project_build_command
+  handler: -> launch_cmd get_project_root!, config.project_build_command
 
 command.register
   name: 'exec',

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -333,9 +333,9 @@ command.register
   handler: launch_cmd
 
 command.register
-  name: 'build-exec'
-  description: 'Runs the command in config.build_command from within the project directory'
-  handler: -> launch_cmd get_project_root!.root, config.build_command
+  name: 'project-build'
+  description: 'Runs the command in config.project_build_command from within the project directory'
+  handler: -> launch_cmd get_project_root!.root, config.project_build_command
 
 command.register
   name: 'exec',
@@ -344,7 +344,7 @@ command.register
   handler: launch_cmd
 
 config.define
-  name: 'build_command'
-  description: 'The command to execute when build-exec is run'
+  name: 'project_build_command'
+  description: 'The command to execute when project-build is run'
   default: 'make'
   type_of: 'string'

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -75,6 +75,7 @@
   ctrl_p:           'project-open'
   ctrl_shift_r:     'exec'
   ctrl_alt_r:       'project-exec'
+  ctrl_shift_b:     'build-exec'
 
   ctrl_w:           'view-close'
   'ctrl_-':         'zoom-out'

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -75,7 +75,7 @@
   ctrl_p:           'project-open'
   ctrl_shift_r:     'exec'
   ctrl_alt_r:       'project-exec'
-  ctrl_shift_b:     'build-exec'
+  ctrl_shift_b:     'project-build'
 
   ctrl_w:           'view-close'
   'ctrl_-':         'zoom-out'

--- a/site/source/doc/manual/running_commands.md
+++ b/site/source/doc/manual/running_commands.md
@@ -55,6 +55,11 @@ off Howl's support for ANSI color escape codes. For less fanciful commands Howl
 will display any standard output plainly, while error output will be shown in a
 different style to allow you to quickly differentiate between the two.
 
+## build-exec
+
+Howl features another execution command, `build-exec`. This is the same as
+`project-exec`, but it executes the command defined in `config.build_command`.
+
 ## Dealing with rogue commands
 
 While a well behaved command will exit on its own, occasionally there are those

--- a/site/source/doc/manual/running_commands.md
+++ b/site/source/doc/manual/running_commands.md
@@ -55,10 +55,10 @@ off Howl's support for ANSI color escape codes. For less fanciful commands Howl
 will display any standard output plainly, while error output will be shown in a
 different style to allow you to quickly differentiate between the two.
 
-## build-exec
+## project-build
 
-Howl features another execution command, `build-exec`. This is the same as
-`project-exec`, but it executes the command defined in `config.build_command`.
+Howl features another execution command, `project-build`, bound to `ctrl_shift_b`. This is the same as
+`project-exec`, but it executes the command defined in `config.project_build_command`.
 
 ## Dealing with rogue commands
 


### PR DESCRIPTION
This is a command I've had in my `init.moon` for a while now since it's quite handy, so I decided to send it in to see if you guys like it. This is *really* useful with projects written in compiled languages (e.g. C++, Crystal, etc.) and also works quite well with my [project extension](https://github.com/kirbyfan64/howl-proj).
